### PR TITLE
Add back NSS Wrapper

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,11 +7,11 @@ name: Docker
 
 on:
   push:
-    branches: [ main, nss ]
+    branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ main, nss ]
+    branches: [ main ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,11 +7,11 @@ name: Docker
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, nss ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, nss ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ENV         NSS_WRAPPER_PASSWD=/tmp/passwd NSS_WRAPPER_GROUP=/tmp/group
 RUN         touch ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
             && chgrp 0 ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
             && chmod g+rw ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP}
+ADD         passwd.template /passwd.template
 
 ## Setup user and working directory
 RUN         useradd -m -d /home/container -s /bin/bash container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,44 @@
-FROM        debian:bullseye-slim
+FROM        --platform=$BUILDPLATFORM debian:stable-slim
 
 LABEL       author="David Wolfe" maintainer="rehlmgaming@gmail.com"
 
-LABEL       org.opencontainers.image.source="https://github.com/pterodactyl/yolks"
+LABEL       org.opencontainers.image.source="https://github.com/parkervcp/yolks"
 LABEL       org.opencontainers.image.licenses=MIT
 
-ENV         DEBIAN_FRONTEND noninteractive
-
 ## Update base packages and install dependencies
+ENV         DEBIAN_FRONTEND=noninteractive
 RUN         dpkg --add-architecture i386 \
-                && apt update \
-                && apt upgrade -y \
-                && apt install -y \
-                    curl \
-                    locales \
-                    ca-certificates \
-                    libssl-dev \
-                    lib32gcc-s1 \
-                    libsdl2-2.0-0 \
-                    libsdl2-2.0-0:i386 \
-                    libstdc++6 \
-                    libstdc++6:i386 \
-                    lib32stdc++6 \
-                    libtbb2 \
-                    libtbb2:i386
+            && apt-get update \
+            && apt-get upgrade -y \
+            && apt-get install -y \
+                curl \
+                tzdata \
+                locales \
+                iproute2 \
+                ca-certificates \
+                libssl-dev \
+                lib32gcc-s1 \
+                libsdl2-2.0-0 \
+                libsdl2-2.0-0:i386 \
+                libstdc++6 \
+                libstdc++6:i386 \
+                lib32stdc++6 \
+                libnss-wrapper \
+                libtbb2 \
+                libtbb2:i386
 
 ## Configure locale
 RUN         update-locale lang=en_US.UTF-8 \
-                && dpkg-reconfigure --frontend noninteractive locales
+            && dpkg-reconfigure --frontend noninteractive locales
+
+## Prepare NSS Wrapper for the entrypoint as a workaround for Arma 3 requiring a valid UID
+ENV         NSS_WRAPPER_PASSWD=/tmp/passwd NSS_WRAPPER_GROUP=/tmp/group
+RUN         touch ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
+            && chgrp 0 ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP} \
+            && chmod g+rw ${NSS_WRAPPER_PASSWD} ${NSS_WRAPPER_GROUP}
 
 ## Setup user and working directory
-RUN         useradd -u 988 -m -d /home/container -s /bin/bash container
-RUN         ln -s /home/container/ /nonexistent
+RUN         useradd -m -d /home/container -s /bin/bash container
 USER        container
 ENV         USER=container HOME=/home/container
 WORKDIR     /home/container

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN         dpkg --add-architecture i386 \
                 tzdata \
                 locales \
                 iproute2 \
+                gettext-base \
                 ca-certificates \
                 libssl-dev \
                 lib32gcc-s1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN         dpkg --add-architecture i386 \
                 libstdc++6:i386 \
                 lib32stdc++6 \
                 libnss-wrapper \
+                libnss-wrapper:i386 \
                 libtbb2 \
                 libtbb2:i386
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 
 ## File: Pterodactyl Arma 3 Image - entrypoint.sh
 ## Author: David Wolfe (Red-Thirten)
-## Contributors: Aussie Server Hosts (https://aussieserverhosts.com/)
-## Date: 2022/01/15
+## Contributors: Aussie Server Hosts (https://aussieserverhosts.com/), Stephen White (SilK)
+## Date: 2022/05/22
 ## License: MIT License
 
 ## === CONSTANTS ===
@@ -20,37 +20,37 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 
 ## === ENVIRONMENT VARS ===
-# STARTUP, STARTUP_PARAMS, STEAM_USER, STEAM_PASS, SERVER_BINARY, MOD_FILE, MODIFICATIONS, SERVERMODS, UPDATE_SERVER, CLEAR_CACHE, VALIDATE_SERVER, MODS_LOWERCASE, STEAMCMD_EXTRA_FLAGS, CDLC, STEAMCMD_APPID, HC_NUM, SERVER_PASSWORD, HC_HIDE, STEAMCMD_ATTEMPTS, BASIC_URL, DISABLE_MOD_UPDATES
+# STARTUP, STARTUP_PARAMS, STEAM_USER, STEAM_PASS, SERVER_BINARY, MOD_FILE, MODIFICATIONS, SERVERMODS, OPTIONALMODS, UPDATE_SERVER, CLEAR_CACHE, VALIDATE_SERVER, MODS_LOWERCASE, STEAMCMD_EXTRA_FLAGS, CDLC, STEAMCMD_APPID, HC_NUM, SERVER_PASSWORD, HC_HIDE, STEAMCMD_ATTEMPTS, BASIC_URL, DISABLE_MOD_UPDATES
 
 ## === GLOBAL VARS ===
 # validateServer, extraFlags, updateAttempt, modifiedStartup, allMods, CLIENT_MODS
 
 ## === DEFINE FUNCTIONS ===
-
+#
 # Runs SteamCMD with specified variables and performs error handling.
-function RunSteamCMD { #[Input: int server=0 mod=1; int id]
+function RunSteamCMD { #[Input: int server=0 mod=1 optional_mod=2; int id]
     # Clear previous SteamCMD log
     if [[ -f "${STEAMCMD_LOG}" ]]; then
         rm -f "${STEAMCMD_LOG:?}"
     fi
-    
+
     updateAttempt=0
     while (( $updateAttempt < $STEAMCMD_ATTEMPTS )); do # Loop for specified number of attempts
         # Increment attempt counter
         updateAttempt=$((updateAttempt+1))
-        
+
         if (( $updateAttempt > 1 )); then # Notify if not first attempt
             echo -e "\t${YELLOW}Re-Attempting download/update in 3 seconds...${NC} (Attempt ${CYAN}${updateAttempt}${NC} of ${CYAN}${STEAMCMD_ATTEMPTS}${NC})\n"
             sleep 3
         fi
-        
+
         # Check if updating server or mod
         if [[ $1 == 0 ]]; then # Server
             ${STEAMCMD_DIR}/steamcmd.sh +force_install_dir /home/container "+login \"${STEAM_USER}\" \"${STEAM_PASS}\"" +app_update $2 $extraFlags $validateServer +quit | tee -a "${STEAMCMD_LOG}"
         else # Mod
             ${STEAMCMD_DIR}/steamcmd.sh "+login \"${STEAM_USER}\" \"${STEAM_PASS}\"" +workshop_download_item $GAME_ID $2 +quit | tee -a "${STEAMCMD_LOG}"
         fi
-        
+
         # Error checking for SteamCMD
         steamcmdExitCode=${PIPESTATUS[0]}
         if [[ -n $(grep -i "error\|failed" "${STEAMCMD_LOG}" | grep -iv "setlocal\|SDL") ]]; then # Catch errors (ignore setlocale and SDL warnings)
@@ -110,7 +110,23 @@ function RunSteamCMD { #[Input: int server=0 mod=1; int id]
                 ModsLowercase @$2
                 # Move any .bikey's to the keys directory
                 echo -e "\tMoving any mod ${CYAN}.bikey${NC} files to the ${CYAN}~/keys/${NC} folder..."
-                find ./@$2 -name "*.bikey" -type f -exec cp {} ./keys \;
+                if [[ $1 == 1 ]]; then
+                    find ./@$2 -name "*.bikey" -type f -exec cp {} ./keys \;
+                else
+                    # Give optional mod keys a custom name which can be checked later for deleting unconfigured mods
+                    for file in $(find ./@$2 -name "*.bikey" -type f); do
+                        filename=$(basename ${file})
+
+                        cp $file ./keys/optional_$2_${filename}
+
+                    done;
+
+                    echo -e "\tMod with ID $2 is an optional mod. Deleting original mod download folder..."
+                    rm -r ./@$2
+
+                    # Recreate a directory so time-based detection of auto updates works correctly
+                    mkdir ./@$2_optional
+                fi
                 echo -e "${GREEN}[UPDATE]: Mod download/update successful!${NC}"
             fi
             break
@@ -149,9 +165,22 @@ function RemoveDuplicates { #[Input: str - Output: printf of new str]
     fi
 }
 
-## === ENTRYPOINT START ===
-cd /home/container
+# === ENTRYPOINT START ===
+
+# Wait for the container to fully initialize
 sleep 1
+
+# Default the TZ environment variable to UTC.
+echo -e "TIMEZONE: ${TZ}"
+TZ=${TZ:-America/Los_Angeles}
+export TZ
+
+# Set environment variable that holds the Internal Docker IP
+INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
+export INTERNAL_IP
+
+# Switch to the container's working directory
+cd /home/container || exit 1
 
 # Check for old eggs
 if [[ -z ${VALIDATE_SERVER} ]]; then # VALIDATE_SERVER was not in the previous version
@@ -162,15 +191,13 @@ if [[ -z ${VALIDATE_SERVER} ]]; then # VALIDATE_SERVER was not in the previous v
     exit 1
 fi
 
-## Collect and parse all specified mods
-# Add manually specified mods to the client-side mods list, while checking for trailing semicolon
-if [[ -n ${MODIFICATIONS} ]] && [[ ${MODIFICATIONS} != *\; ]]; then
+# Collect and parse all specified mods
+if [[ -n ${MODIFICATIONS} ]] && [[ ${MODIFICATIONS} != *\; ]]; then # Add manually specified mods to the client-side mods list, while checking for trailing semicolon
     CLIENT_MODS="${MODIFICATIONS};"
 else
     CLIENT_MODS=${MODIFICATIONS}
 fi
-# If the mod list file exists and is valid, parse and add mods to the client-side mods list
-if [[ -f ${MOD_FILE} ]] && [[ -n "$(cat ${MOD_FILE} | grep 'Created by Arma 3 Launcher')" ]]; then
+if [[ -f ${MOD_FILE} ]] && [[ -n "$(cat ${MOD_FILE} | grep 'Created by Arma 3 Launcher')" ]]; then # If the mod list file exists and is valid, parse and add mods to the client-side mods list
     CLIENT_MODS+=$(cat ${MOD_FILE} | grep 'id=' | cut -d'=' -f3 | cut -d'"' -f1 | xargs printf '@%s;')
 elif [[ -n "${MOD_FILE}" ]]; then # If MOD_FILE is not null, warn user file is missing or invalid
     echo -e "\n${YELLOW}[STARTUP_WARN]: Arma 3 Modlist file \"${CYAN}${MOD_FILE}${YELLOW}\" could not be found, or is invalid!${NC}"
@@ -180,11 +207,15 @@ elif [[ -n "${MOD_FILE}" ]]; then # If MOD_FILE is not null, warn user file is m
         echo -e "\t${CYAN}Reverting to the manual mod list...${NC}"
     fi
 fi
-# Add server mods to the master mods list, while checking for trailing semicolon
-if [[ -n ${SERVERMODS} ]] && [[ ${SERVERMODS} != *\; ]]; then
+if [[ -n ${SERVERMODS} ]] && [[ ${SERVERMODS} != *\; ]]; then # Add server mods to the master mods list, while checking for trailing semicolon
     allMods="${SERVERMODS};"
 else
     allMods=${SERVERMODS}
+fi
+if [[ -n ${OPTIONALMODS} ]] && [[ ${OPTIONALMODS} != *\; ]]; then # Add specified optional mods to the mods list, while checking for trailing semicolon
+    allMods+="${OPTIONALMODS};"
+else
+    allMods+=${OPTIONALMODS}
 fi
 allMods+=$CLIENT_MODS # Add all client-side mods to the master mod list
 CLIENT_MODS=$(RemoveDuplicates ${CLIENT_MODS}) # Remove duplicate mods from CLIENT_MODS, if present
@@ -195,17 +226,17 @@ allMods=$(echo $allMods | sed -e 's/;/ /g') # Convert from string to array
 if [[ ${UPDATE_SERVER} == 1 ]]; then
     echo -e "\n${GREEN}[STARTUP]: ${CYAN}Starting checks for all updates...${NC}"
     echo -e "(It is okay to ignore any \"SDL\" errors during this process)\n"
-    
+
     ## Update game server
     echo -e "${GREEN}[UPDATE]:${NC} Checking for game server updates with App ID: ${CYAN}${STEAMCMD_APPID}${NC}..."
-    
+
     if [[ ${VALIDATE_SERVER} == 1 ]]; then # Validate will be added as a parameter if specified
         echo -e "\t${CYAN}File validation enabled.${NC} (This may take extra time to complete)"
         validateServer="validate"
     else
         validateServer=""
     fi
-    
+
     # Determine what extra flags should be set
     if [[ -n ${STEAMCMD_EXTRA_FLAGS} ]]; then
         echo -e "\t(${YELLOW}Advanced${NC}) Extra SteamCMD flags specified: ${CYAN}${STEAMCMD_EXTRA_FLAGS}${NC}\n"
@@ -217,25 +248,37 @@ if [[ ${UPDATE_SERVER} == 1 ]]; then
         echo -e ""
         extraFlags=""
     fi
-    
+
     RunSteamCMD 0 ${STEAMCMD_APPID}
-    
+
     ## Update mods
     if [[ -n $allMods ]] && [[ ${DISABLE_MOD_UPDATES} != 1 ]]; then
         echo -e "\n${GREEN}[UPDATE]:${NC} Checking all ${CYAN}Steam Workshop mods${NC} for updates..."
         for modID in $(echo $allMods | sed -e 's/@//g')
         do
             if [[ $modID =~ ^[0-9]+$ ]]; then # Only check mods that are in ID-form
+                # If a mod is defined in OPTIONALMODS, and is not defined in CLIENT_MODS or SERVERMODS, then treat as an optional mod
+                # Optional mods are given a different directory which is checked to see if a new update is available. This is to ensure
+                # if an optional mod is switched to be a standard client-side mod, this script will redownload the mod
+                if [[ "${OPTIONALMODS}" == *"@${modID};"* ]] && [[ "${CLIENT_MODS}" != *"@${modID};"* ]] && [[ "${SERVERMODS}" != *"@${modID};"* ]]; then
+                    modType=2
+                    modDir=@${modID}_optional
+                else
+                    modType=1
+                    modDir=@${modID}
+                fi
+
                 # Get mod's latest update in epoch time from its Steam Workshop changelog page
                 latestUpdate=$(curl -sL https://steamcommunity.com/sharedfiles/filedetails/changelog/$modID | grep '<p id=' | head -1 | cut -d'"' -f2)
+
                 # If the update time is valid and newer than the local directory's creation date, or the mod hasn't been downloaded yet, download the mod
-                if [[ ! -d @$modID ]] || [[ ( -n $latestUpdate ) && ( $latestUpdate =~ ^[0-9]+$ ) && ( $latestUpdate > $(find @$modID | head -1 | xargs stat -c%Y) ) ]]; then
+                if [[ ! -d $modDir ]] || [[ ( -n $latestUpdate ) && ( $latestUpdate =~ ^[0-9]+$ ) && ( $latestUpdate > $(find $modDir | head -1 | xargs stat -c%Y) ) ]]; then
                     # Get the mod's name from the Workshop page as well
                     modName=$(curl -sL https://steamcommunity.com/sharedfiles/filedetails/changelog/$modID | grep 'workshopItemTitle' | cut -d'>' -f2 | cut -d'<' -f1)
                     if [[ -z $modName ]]; then # Set default name if unavailable
                         modName="[NAME UNAVAILABLE]"
                     fi
-                    if [[ ! -d @$modID ]]; then
+                    if [[ ! -d $modDir ]]; then
                         echo -e "\n${GREEN}[UPDATE]:${NC} Downloading new Mod: \"${CYAN}${modName}${NC}\" (${CYAN}${modID}${NC})"
                     else
                         echo -e "\n${GREEN}[UPDATE]:${NC} Mod update found for: \"${CYAN}${modName}${NC}\" (${CYAN}${modID}${NC})"
@@ -244,10 +287,38 @@ if [[ ${UPDATE_SERVER} == 1 ]]; then
                         echo -e "\tMod was last updated: ${CYAN}$(date -d @${latestUpdate})${NC}"
                     fi
                     echo -e "\tAttempting mod update/download via SteamCMD...\n"
-                    RunSteamCMD 1 $modID
+
+                    RunSteamCMD $modType $modID
                 fi
             fi
         done
+
+        # Check over key files for unconfigured optional mods' .bikey files
+        for keyFile in $(find ./keys -name "*.bikey" -type f); do
+            keyFileName=$(basename ${keyFile})
+
+            # If the key file is using the optional mod file name
+            if [[ "${keyFileName}" == "optional_"* ]]; then
+                modID=$(echo "${keyFileName}" | cut -d _ -f 2)
+
+                # If mod is not in optional mods, delete it
+                # If a mod is configured in CLIENT_MODS or SERVERMODS, we should still delete this file
+                # as a new file will have been copied that does not follow the naming scheme
+                if [[ "${OPTIONALMODS}" != *"@${modID};"* ]]; then
+
+                    # We only need to let the user know the key file is being deleted if this mod is no longer configured at all.
+                    # If CLIENT_MODS contains the mod ID, we'd just confuse the user by telling them we are deleting the optional .bikey file
+                    if [[ "${CLIENT_MODS}" != *"@${modID};"* ]]; then
+                        echo -e "\tKey file and directory for unconfigured optional mod ${CYAN}${modID}${NC} is being deleted..."
+                    fi
+
+                    # Delete the optional mod .bikey file and directory
+                    rm ${keyFile}
+                    rmdir ./@${modID}_optional 2> /dev/null
+                fi
+            fi
+        done;
+
         echo -e "${GREEN}[UPDATE]:${NC} Steam Workshop mod update check ${GREEN}complete${NC}!"
     fi
 fi
@@ -286,6 +357,18 @@ if [[ ! -f ./basic.cfg ]]; then
     echo -e "\t${YELLOW}Downloading default file for use instead...${NC}"
     curl -sSL ${BASIC_URL} -o ./basic.cfg
 fi
+
+# Setup NSS Wrapper for use ($NSS_WRAPPER_PASSWD and $NSS_WRAPPER_GROUP have been set by the Dockerfile)
+export USER_ID=$(id -u)
+export GROUP_ID=$(id -g)
+envsubst < /passwd.template > ${NSS_WRAPPER_PASSWD}
+
+# if [[ ${SERVER_BINARY} == *"x64"* ]]; then # Check which libnss_wrapper architecture to run, based off the server binary name
+    # export LD_PRELOAD=/libnss_wrapper_x64.so
+# else
+    # export LD_PRELOAD=/libnss_wrapper.so
+# fi
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
 
 # Replace Startup Variables
 modifiedStartup=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -358,11 +358,11 @@ export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 envsubst < /passwd.template > ${NSS_WRAPPER_PASSWD}
 
-# if [[ ${SERVER_BINARY} == *"x64"* ]]; then # Check which libnss-wrapper architecture to run, based off the server binary name
-    # export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
-# else
-    # export LD_PRELOAD=/usr/lib/i386-linux-gnu/libnss_wrapper.so
-# fi
+if [[ ${SERVER_BINARY} == *"x64"* ]]; then # Check which libnss-wrapper architecture to run, based off the server binary name
+    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+else
+    export LD_PRELOAD=/usr/lib/i386-linux-gnu/libnss_wrapper.so
+fi
 
 # Replace Startup Variables
 modifiedStartup=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -358,11 +358,11 @@ export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 envsubst < /passwd.template > ${NSS_WRAPPER_PASSWD}
 
-if [[ ${SERVER_BINARY} == *"x64"* ]]; then # Check which libnss-wrapper architecture to run, based off the server binary name
-    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
-else
-    export LD_PRELOAD=/usr/lib/i386-linux-gnu/libnss_wrapper.so
-fi
+# if [[ ${SERVER_BINARY} == *"x64"* ]]; then # Check which libnss-wrapper architecture to run, based off the server binary name
+    # export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+# else
+    # export LD_PRELOAD=/usr/lib/i386-linux-gnu/libnss_wrapper.so
+# fi
 
 # Replace Startup Variables
 modifiedStartup=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -170,11 +170,6 @@ function RemoveDuplicates { #[Input: str - Output: printf of new str]
 # Wait for the container to fully initialize
 sleep 1
 
-# Default the TZ environment variable to UTC.
-echo -e "TIMEZONE: ${TZ}"
-TZ=${TZ:-America/Los_Angeles}
-export TZ
-
 # Set environment variable that holds the Internal Docker IP
 INTERNAL_IP=$(ip route get 1 | awk '{print $(NF-2);exit}')
 export INTERNAL_IP
@@ -363,12 +358,11 @@ export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 envsubst < /passwd.template > ${NSS_WRAPPER_PASSWD}
 
-# if [[ ${SERVER_BINARY} == *"x64"* ]]; then # Check which libnss_wrapper architecture to run, based off the server binary name
-    # export LD_PRELOAD=/libnss_wrapper_x64.so
-# else
-    # export LD_PRELOAD=/libnss_wrapper.so
-# fi
-export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+if [[ ${SERVER_BINARY} == *"x64"* ]]; then # Check which libnss-wrapper architecture to run, based off the server binary name
+    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+else
+    export LD_PRELOAD=/usr/lib/i386-linux-gnu/libnss_wrapper.so
+fi
 
 # Replace Startup Variables
 modifiedStartup=`eval echo $(echo ${STARTUP} | sed -e 's/{{/${/g' -e 's/}}/}/g')`

--- a/passwd.template
+++ b/passwd.template
@@ -1,0 +1,26 @@
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/var/run/ircd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+systemd-timesync:x:100:102:systemd Time Synchronization,,,:/run/systemd:/bin/false
+systemd-network:x:101:103:systemd Network Management,,,:/run/systemd/netif:/bin/false
+systemd-resolve:x:102:104:systemd Resolver,,,:/run/systemd/resolve:/bin/false
+systemd-bus-proxy:x:103:105:systemd Bus Proxy,,,:/run/systemd:/bin/false
+syslog:x:104:108::/home/syslog:/bin/false
+messagebus:x:106:109::/var/run/dbus:/bin/false
+bind:x:108:112::/var/cache/bind:/bin/false
+${USER}:x:${USER_ID}:${GROUP_ID}:${USER}:${HOME}:/bin/bash


### PR DESCRIPTION
- Add back libnss-wrapper (with fixes) to avoid static UID
- General NSS Wrapper cleanup compared to original production image (fixed 32-bit and no longer needs standalone `.so` files)
- Bring entrypoint.sh up to date with current production image (optional mods)
- Add `tzdata`, `iproute2`, and `gettext-base` packages